### PR TITLE
Ability to set a fixed seed for AUCell and regulon thresholds derivation

### DIFF
--- a/src/pyscenic/aucell.py
+++ b/src/pyscenic/aucell.py
@@ -23,7 +23,7 @@ DTYPE = 'uint32'
 DTYPE_C = c_uint32
 
 
-def create_rankings(ex_mtx: pd.DataFrame) -> pd.DataFrame:
+def create_rankings(ex_mtx: pd.DataFrame, seed=None) -> pd.DataFrame:
     """
     Create a whole genome rankings dataframe from a single cell expression profile dataframe.
 
@@ -44,7 +44,7 @@ def create_rankings(ex_mtx: pd.DataFrame) -> pd.DataFrame:
     #    # Run below statement multiple times to see effect of shuffling in case of a tie.
     #    df.sample(frac=1.0, replace=False).rank(ascending=False, method='first', na_option='bottom').sort_index() - 1
     #
-    return ex_mtx.sample(frac=1.0, replace=False, axis=1).rank(axis=1, ascending=False, method='first', na_option='bottom').astype(DTYPE) - 1
+    return ex_mtx.sample(frac=1.0, replace=False, axis=1, random_state=seed).rank(axis=1, ascending=False, method='first', na_option='bottom').astype(DTYPE) - 1
 
 
 def derive_auc_threshold(ex_mtx: pd.DataFrame) -> pd.DataFrame:
@@ -140,6 +140,7 @@ def aucell4r(df_rnk: pd.DataFrame, signatures: Sequence[Type[GeneSignature]],
 
 def aucell(exp_mtx: pd.DataFrame, signatures: Sequence[Type[GeneSignature]],
            auc_threshold: float = 0.05, noweights: bool = False, normalize: bool = False,
+           seed=None,
            num_workers: int = cpu_count()) -> pd.DataFrame:
     """
     Calculate enrichment of gene signatures for single cells.
@@ -153,5 +154,5 @@ def aucell(exp_mtx: pd.DataFrame, signatures: Sequence[Type[GeneSignature]],
     :param num_workers: The number of cores to use.
     :return: A dataframe with the AUCs (n_cells x n_modules).
     """
-    return aucell4r(create_rankings(exp_mtx), signatures, auc_threshold, noweights, normalize, num_workers)
+    return aucell4r(create_rankings(exp_mtx, seed), signatures, auc_threshold, noweights, normalize, num_workers)
 

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -198,7 +198,7 @@ def aucell_command(args):
     if extension == '.loom':
         try:
             copyfile(args.expression_mtx_fname.name, args.output.name)
-            append_auc_mtx(args.output.name, auc_mtx, signatures, args.num_workers)
+            append_auc_mtx(args.output.name, auc_mtx, signatures, args.seed, args.num_workers)
         except OSError as e:
             LOGGER.error("Expression matrix should be provided in the loom file format.")
             sys.exit(1)

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -190,6 +190,7 @@ def aucell_command(args):
     auc_mtx = aucell(ex_mtx, signatures,
                          auc_threshold=args.auc_threshold,
                          noweights=(args.weights != 'yes'),
+                         seed=args.seed,
                          num_workers=args.num_workers)
 
     LOGGER.info("Writing results to file.")
@@ -390,6 +391,8 @@ def create_argument_parser():
     parser_aucell.add_argument('--num_workers',
                        type=int, default=cpu_count(),
                        help='The number of workers to use (default: {}).'.format(cpu_count()))
+    parser_aucell.add_argument('--seed', type=int, required=False, default=None,
+                            help='Seed for the expression matrix ranking step. The default is to use a random seed.')
     add_recovery_parameters(parser_aucell)
     add_loom_parameters(parser_aucell)
     parser_aucell.set_defaults(func=aucell_command)

--- a/src/pyscenic/cli/utils.py
+++ b/src/pyscenic/cli/utils.py
@@ -218,7 +218,7 @@ def compress_meta(meta):
     return base64.b64encode(zlib.compress(json.dumps(meta).encode('ascii'))).decode('ascii')
 
 
-def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[GeneSignature]], num_workers=1) -> None:
+def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[GeneSignature]], seed=None, num_workers=1) -> None:
     """
 
     Append AUC matrix to loom file.
@@ -239,7 +239,7 @@ def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[Ge
         name2logo = {}
 
     # Binarize matrix for AUC thresholds.
-    _, auc_thresholds = binarize(auc_mtx, num_workers=num_workers)
+    _, auc_thresholds = binarize(auc_mtx, seed=seed, num_workers=num_workers)
     regulon_thresholds = [{"regulon": name,
                            "defaultThresholdValue":(threshold if isinstance(threshold, float) else threshold[0]),
                            "defaultThresholdName": "guassian_mixture_split",
@@ -284,3 +284,4 @@ def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[Ge
             meta_data = {}
         meta_data["regulonThresholds"] = regulon_thresholds
         ds.attrs[ATTRIBUTE_NAME_METADATA] = compress_meta(meta_data)
+

--- a/src/pyscenic/cli/utils.py
+++ b/src/pyscenic/cli/utils.py
@@ -242,8 +242,8 @@ def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[Ge
     _, auc_thresholds = binarize(auc_mtx, seed=seed, num_workers=num_workers)
     regulon_thresholds = [{"regulon": name,
                            "defaultThresholdValue":(threshold if isinstance(threshold, float) else threshold[0]),
-                           "defaultThresholdName": "guassian_mixture_split",
-                           "allThresholds": {"guassian_mixture_split": (threshold if isinstance(threshold, float) else threshold[0])},
+                           "defaultThresholdName": "gaussian_mixture_split",
+                           "allThresholds": {"gaussian_mixture_split": (threshold if isinstance(threshold, float) else threshold[0])},
                            "motifData": name2logo.get(name, "")} for name, threshold in auc_thresholds.iteritems()]
 
     # Calculate the number of genes per cell.

--- a/src/pyscenic/export.py
+++ b/src/pyscenic/export.py
@@ -148,8 +148,8 @@ def export2loom(ex_mtx: pd.DataFrame, regulons: List[Regulon], out_fname: str,
     name2logo = {reg.name: fetch_logo(reg.context) for reg in regulons}
     regulon_thresholds = [{"regulon": name,
                             "defaultThresholdValue":(threshold if isinstance(threshold, float) else threshold[0]),
-                            "defaultThresholdName": "guassian_mixture_split",
-                            "allThresholds": {"guassian_mixture_split": (threshold if isinstance(threshold, float) else threshold[0])},
+                            "defaultThresholdName": "gaussian_mixture_split",
+                            "allThresholds": {"gaussian_mixture_split": (threshold if isinstance(threshold, float) else threshold[0])},
                             "motifData": name2logo.get(name, "")} for name, threshold in auc_thresholds.iteritems()]
 
     general_attrs = {


### PR DESCRIPTION
AUCell uses a random sampling of the expression matrix to break ties in the ranking step. The CLI parameter `--seed` or `aucell` function parameter `seed` uses a fixed seed for this step

The regulon thresholds also depend on random sampling in the binarization step (bimodality test: `np.random.uniform`), and the seed parameters apply here as well.