### PR TITLE
CLI: Add gzip support for intermediate files

### DIFF
--- a/scripts/arboreto_with_multiprocessing.py
+++ b/scripts/arboreto_with_multiprocessing.py
@@ -22,17 +22,17 @@ from pyscenic.cli.utils import load_exp_matrix
 parser_grn = argparse.ArgumentParser(description='Run Arboreto using a multiprocessing pool')
 
 parser_grn.add_argument('expression_mtx_fname',
-        type=argparse.FileType('r'),
+        type=str,
         help='The name of the file that contains the expression matrix for the single cell experiment.'
         ' Two file formats are supported: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells).')
 parser_grn.add_argument('tfs_fname',
-        type=argparse.FileType('r'),
+        type=str,
         help='The name of the file that contains the list of transcription factors (TXT; one TF per line).')
 parser_grn.add_argument('-m', '--method', choices=['genie3', 'grnboost2'],
         default='grnboost2',
         help='The algorithm for gene regulatory network reconstruction (default: grnboost2).')
 parser_grn.add_argument('-o', '--output',
-        type=argparse.FileType('w'), default=sys.stdout,
+        type=str, default=sys.stdout,
         help='Output file/stream, i.e. a table of TF-target genes (TSV).')
 parser_grn.add_argument('--num_workers',
         type=int, default=cpu_count(),
@@ -90,7 +90,7 @@ def run_infer_partial_network(target_gene_index):
 if __name__ == '__main__':
 
     start_time = time.time()
-    ex_matrix = load_exp_matrix(args.expression_mtx_fname.name,
+    ex_matrix = load_exp_matrix(args.expression_mtx_fname,
                              (args.transpose == 'yes'),
                              args.sparse,
                              args.cell_id_attribute,
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     end_time = time.time()
     print(f'Loaded expression matrix of {ex_matrix.shape[0]} cells and {ex_matrix.shape[1]} genes in {end_time - start_time} seconds...', file=sys.stdout)
 
-    tf_names = load_tf_names(args.tfs_fname.name)
+    tf_names = load_tf_names(args.tfs_fname)
     print(f'Loaded {len(tf_names)} TFs...', file=sys.stdout)
 
     ex_matrix, gene_names, tf_names = _prepare_input(ex_matrix, gene_names, tf_names)
@@ -126,5 +126,5 @@ if __name__ == '__main__':
     end_time = time.time()
     print(f'Done in {end_time - start_time} seconds.', file=sys.stdout)
 
-    adj.to_csv(args.output, index=False, sep="\t")
+    adj.to_csv(args.output, index=False, sep='\t')
 

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -24,6 +24,8 @@ from pyscenic.log import create_logging_handler
 import sys
 from typing import Type, Sequence
 from .utils import load_exp_matrix, load_signatures, save_matrix, save_enriched_motifs, load_adjacencies, load_modules, append_auc_mtx, ATTRIBUTE_NAME_CELL_IDENTIFIER, ATTRIBUTE_NAME_GENE
+from .utils import is_valid_suffix, suffixes_to_separator
+from pathlib import Path, PurePath
 
 try:
     from pyscenic._version import get_versions
@@ -75,9 +77,8 @@ def find_adjacencies_command(args):
 
     LOGGER.info("Writing results to file.")
 
-    extension = os.path.splitext(args.output.name)[1].lower()
-    separator = '\t' if extension == '.tsv' else ','
-    network.to_csv(args.output, index=False, sep=separator)
+    extension = PurePath(fname).suffixes
+    network.to_csv(args.output, index=False, sep=suffixes_to_separator(extension))
 
 
 def adjacencies2modules(args):
@@ -130,8 +131,8 @@ def prune_targets_command(args):
     # Potential improvements are switching to JSON or to use a CLoader:
     # https://stackoverflow.com/questions/27743711/can-i-speedup-yaml
     # The alternative for which was opted in the end is binary pickling.
-    extension = os.path.splitext(args.module_fname.name)[1].lower()
-    if extension in {'.csv', '.tsv'}:
+    extension = PurePath(args.module_fname.name).suffixes
+    if is_valid_suffix(extension, 'ctx'):
         if args.expression_mtx_fname is None:
             LOGGER.error("No expression matrix is supplied.")
             sys.exit(0)
@@ -201,8 +202,8 @@ def aucell_command(args):
                          num_workers=args.num_workers)
 
     LOGGER.info("Writing results to file.")
-    extension = os.path.splitext(args.output.name)[1].lower()
-    if extension == '.loom':
+    extension = PurePath(args.output.name).suffixes
+    if '.loom' in extension:
         try:
             copyfile(args.expression_mtx_fname.name, args.output.name)
             append_auc_mtx(args.output.name, auc_mtx, signatures, args.seed, args.num_workers)

--- a/src/pyscenic/utils.py
+++ b/src/pyscenic/utils.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 from urllib.parse import urljoin
-from .genesig import Regulon, GeneSignature
+from .genesig import Regulon, GeneSignature, openfile
 from .math import masked_rho4pairs
 from itertools import chain
 import numpy as np
@@ -292,7 +292,7 @@ def save_to_yaml(signatures: Sequence[Type[GeneSignature]], fname: str):
     :param signatures:
     :return:
     """
-    with open(fname, 'w') as f:
+    with openfile(fname, 'w') as f:
         f.write(dump(signatures, default_flow_style=False, Dumper=Dumper))
 
 
@@ -302,7 +302,7 @@ def load_from_yaml(fname: str) -> Sequence[Type[GeneSignature]]:
     :param fname:
     :return:
     """
-    with open(fname, 'r') as f:
+    with openfile(fname, 'r') as f:
         return load(f.read(), Loader=Loader)
 
 
@@ -333,7 +333,5 @@ def load_motifs(fname: str, sep: str = ',') -> pd.DataFrame:
     df[('Enrichment', COLUMN_NAME_CONTEXT)] = df[('Enrichment', COLUMN_NAME_CONTEXT)].apply(lambda s: eval(s))
     df[('Enrichment', COLUMN_NAME_TARGET_GENES)] = df[('Enrichment', COLUMN_NAME_TARGET_GENES)].apply(lambda s: eval(s))
     return df
-
-
 
 


### PR DESCRIPTION
- Added methods to determine the file extension (which might contain a `.gz` ending)
- Reworked tests to determine which file import/export function to use
- Added optional gzip file connection to gene signatures
- Pandas read/write infers compression automatically from the file ending

Intermediate files are compressed based on the filename given in the command line arguments.