### PR TITLE
fixed weight assignment when computing leading edge

### DIFF
--- a/src/pyscenic/recovery.py
+++ b/src/pyscenic/recovery.py
@@ -179,7 +179,7 @@ def leading_edge(rcc: np.ndarray, avg2stdrcc: np.ndarray,
         # but is inline with the RcisTarget implementation.
         filtered_idx = sranking <= rank_at_max
         filtered_gene_ids = gene_ids[filtered_idx]
-        return list(zip(filtered_gene_ids, weights[filtered_idx] if weights is not None else sranking[filtered_idx]))
+        return list(zip(filtered_gene_ids, weights[sorted_idx][filtered_idx] if weights is not None else sranking[filtered_idx]))
 
     rank_at_max, n_recovered_genes = critical_point()
     # noinspection PyTypeChecker


### PR DESCRIPTION
Weights of genes in final regulons didn't match the weights from the regression (adjacencies data frame). 

The problem is when we compute the leading edge, where genes are sorted by ranking for pruning. Then, when we assign them the weights back, weights are sorted by alphabetical order. This leads to a gene-weight mismatch. 

The **leading_edge function** in the _recovery.py_ file was modified, so the weights get also sorted by ranking and the weight assignment now is fixed. 