### PR TITLE
Development updates for 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 python:
     - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 dist: bionic
+
 language: python
-python:
-    - "3.6"
+
+matrix:
+  include:
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
+
 install: pip install tox-travis
+
 script: tox
-#deploy:
-#  provider: pypi
-#  user: ""
-#  password:
-#    secure: ""
-#  on:
-#    tags: true
+

--- a/README.rst
+++ b/README.rst
@@ -14,27 +14,31 @@ in no time. The latter is achieved via the dask_ framework for distributed compu
 
 **Full documentation** is available on `Read the Docs <https://pyscenic.readthedocs.io/en/latest/>`_
 
-News
-----
+News and releases
+-----------------
 
-2020-05-17
-^^^^^^^^^^
+0.10.2 | 2020-06-05
+^^^^^^^^^^^^^^^^^^^
 
-**0.10.1 release**
+* Bugfix for CLI grn step
+
+
+0.10.1 | 2020-05-17
+^^^^^^^^^^^^^^^^^^^
 
 * CLI: file compression (optionally) enabled for intermediate files for the major steps: grn (adjacencies matrix), ctx (regulons), and aucell (auc matrix). Compression is used when the file name argument has a .gz ending.
 
 
-2020-02-27
-^^^^^^^^^^
-
-**0.10.0 release**
+0.10.0 | 2020-02-27
+^^^^^^^^^^^^^^^^^^^
 
 * Added a helper script `arboreto_with_multiprocessing.py <https://github.com/aertslab/pySCENIC/blob/master/src/pyscenic/cli/arboreto_with_multiprocessing.py>`_ that runs the Arboreto GRN algorithms (GRNBoost2, GENIE3) without Dask for compatibility.
 
 * Ability to set a fixed seed in both the AUCell step and in the calculation of regulon thresholds (CLI parameter :code:`--seed`; aucell function parameter :code:`seed`).
 
 * (since 0.9.18) In the modules_from_adjacencies function, the default value of :code:`rho_mask_dropouts` is changed to False. This now matches the behavior of the R version of SCENIC. The cli version has an additional option to turn dropout masking back on (:code:`--mask_dropouts`).
+
+See also the extended `Release Notes <https://pyscenic.readthedocs.io/en/latest/releasenotes.html>`_.
 
 Overview
 --------

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,15 @@ in no time. The latter is achieved via the dask_ framework for distributed compu
 News and releases
 -----------------
 
+0.10.3 | 2020-07-15
+^^^^^^^^^^^^^^^^^^^
+
+* Integrate arboreto multiprocessing script into pySCENIC CLI
+* Skip modules with zero db overlap in cisTarget step
+* Additional error message if regulons file is empty
+* Additional error if there is a mismatch between the genes present in the GRN and the expression matrix
+* Fixed bug in motif url construciton when running without pruning
+
 0.10.2 | 2020-06-05
 ^^^^^^^^^^^^^^^^^^^
 
@@ -29,15 +38,6 @@ News and releases
 
 * CLI: file compression (optionally) enabled for intermediate files for the major steps: grn (adjacencies matrix), ctx (regulons), and aucell (auc matrix). Compression is used when the file name argument has a .gz ending.
 
-
-0.10.0 | 2020-02-27
-^^^^^^^^^^^^^^^^^^^
-
-* Added a helper script `arboreto_with_multiprocessing.py <https://github.com/aertslab/pySCENIC/blob/master/src/pyscenic/cli/arboreto_with_multiprocessing.py>`_ that runs the Arboreto GRN algorithms (GRNBoost2, GENIE3) without Dask for compatibility.
-
-* Ability to set a fixed seed in both the AUCell step and in the calculation of regulon thresholds (CLI parameter :code:`--seed`; aucell function parameter :code:`seed`).
-
-* (since 0.9.18) In the modules_from_adjacencies function, the default value of :code:`rho_mask_dropouts` is changed to False. This now matches the behavior of the R version of SCENIC. The cli version has an additional option to turn dropout masking back on (:code:`--mask_dropouts`).
 
 See also the extended `Release Notes <https://pyscenic.readthedocs.io/en/latest/releasenotes.html>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -18,21 +18,30 @@ in no time. The latter is achieved via the dask_ framework for distributed compu
 News and releases
 -----------------
 
-dev | 2020-12-10
+0.11.0 | 2021-02-10
 ^^^^^^^^^^^^^^^^
 
 **Major features:**
 
-* cisTarget databases:
+* Updated `Arboreto <https://github.com/aertslab/arboreto>`_ release (GRN inference step) includes:
 
-  * Support for Apache Parquet format
-  * Feather V2 (0.17.0+) compatibility
+  * Support for sparse matrices (using the ``--sparse`` flag in ``pyscenic grn``, or passing a sparse matrix to ``grnboost2``/``genie3``).
+  * Fixes to avoid dask metadata mismatch error
+
+* Updated cisTarget:
+
+  * Fix for metadata mismatch in ctx prune2df step
+  * Support for databases Apache Parquet format
   * Faster loading from feather databases
-  * Bugfix: loading genes from a database (previously the last gene name in the database)
+  * Bugfix: loading genes from a database (previously missing the last gene name in the database)
 
 * Support for Anndata input and output
 
-* Upgrade to new pandas version
+* Package updates:
+
+  * Upgrade to newer pandas version
+  * Upgrade to newer numba version
+  * Upgrade to newer versions of dask, distributed
 
 * Input checks and more descriptive error messages.
 
@@ -43,6 +52,8 @@ dev | 2020-12-10
   * Motif url construction fixed when running ctx without pruning
   * Compression of intermediate files in the CLI steps
   * Handle loom files with non-standard gene/cell attribute names
+  * Reformat the genesig gmt input/output
+  * Fix AUCell output to loom with non-standard loom attributes
 
 
 0.10.4 | 2020-11-24
@@ -50,25 +61,6 @@ dev | 2020-12-10
 
 * Included new CLI option to add correlation information to the GRN adjacencies file. This can be called with ``pyscenic add_cor``.
 
-0.10.3 | 2020-07-15
-^^^^^^^^^^^^^^^^^^^
-
-* Integrate arboreto multiprocessing script into pySCENIC CLI
-* Skip modules with zero db overlap in cisTarget step
-* Additional error message if regulons file is empty
-* Additional error if there is a mismatch between the genes present in the GRN and the expression matrix
-* Fixed bug in motif url construciton when running without pruning
-
-0.10.2 | 2020-06-05
-^^^^^^^^^^^^^^^^^^^
-
-* Bugfix for CLI grn step
-
-
-0.10.1 | 2020-05-17
-^^^^^^^^^^^^^^^^^^^
-
-* CLI: file compression (optionally) enabled for intermediate files for the major steps: grn (adjacencies matrix), ctx (regulons), and aucell (auc matrix). Compression is used when the file name argument has a .gz ending.
 
 
 See also the extended `Release Notes <https://pyscenic.readthedocs.io/en/latest/releasenotes.html>`_.
@@ -121,8 +113,8 @@ References
 .. |buildstatus| image:: https://travis-ci.org/aertslab/pySCENIC.svg?branch=master
 .. _buildstatus: https://travis-ci.org/aertslab/pySCENIC
 
-.. |pypipackage| image:: https://badge.fury.io/py/pyscenic.svg
-.. _pypipackage: https://badge.fury.io/py/pyscenic
+.. |pypipackage| image:: https://img.shields.io/pypi/v/pySCENIC?color=%23026aab
+.. _pypipackage: https://pypi.org/project/pyscenic/
 
 .. |docstatus| image:: https://readthedocs.org/projects/pyscenic/badge/?version=latest
 .. _docstatus: http://pyscenic.readthedocs.io/en/latest/?badge=latest

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,7 @@ Clustering) which enables biologists to infer transcription factors, gene regula
 single-cell RNA-seq data.
 
 The pioneering work was done in R and results were published in Nature Methods [1]_.
+A new and comprehensive description of this Python implementation of the SCENIC pipeline is available in Nature Protocols [5]_ (`see here <https://doi.org/10.1038/s41596-020-0336-2>`_).
 
 pySCENIC can be run on a single desktop machine but easily scales to multi-core clusters to analyze thousands of cells
 in no time. The latter is achieved via the dask_ framework for distributed computing [2]_.
@@ -83,6 +84,7 @@ References
 .. [2] Rocklin, M. Dask: parallel computation with blocked algorithms and task scheduling. conference.scipy.org
 .. [3] Huynh-Thu, V. A. et al. Inferring regulatory networks from expression data using tree-based methods. PLoS ONE 5, (2010).
 .. [4] Zeisel, A. et al. Cell types in the mouse cortex and hippocampus revealed by single-cell RNA-seq. Science 347, 1138–1142 (2015).
+.. [5] Van de Sande B., Flerin C., et al. A scalable SCENIC workflow for single-cell gene regulatory network analysis. Nat Protoc. June 2020:1-30. doi:10.1038/s41596-020-0336-2
 
 .. |buildstatus| image:: https://travis-ci.org/aertslab/pySCENIC.svg?branch=master
 .. _buildstatus: https://travis-ci.org/aertslab/pySCENIC

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,31 @@ in no time. The latter is achieved via the dask_ framework for distributed compu
 News and releases
 -----------------
 
+dev | 2020-08-31
+^^^^^^^^^^^^^^^^
+
+**Major features:**
+
+* cisTarget databases:
+
+  * Support for Apache Parquet format
+  * Feather V2 (0.17.0+) compatibility
+  * Faster loading from feather databases
+  * Bugfix: loading genes from a database (previously the last gene name in the database)
+
+* Support for Anndata input and output
+
+* Upgrade to new pandas version
+
+* Input checks and more descriptive error messages.
+
+  * Check that regulons loaded are not empty.
+
+* Bugfixes:
+
+  * Motif url construction fixed when running ctx without pruning
+  * Compression of intermediate files in the CLI steps
+
 0.10.3 | 2020-07-15
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
    installation
    tutorial
    faq
+   releasenotes
 
 .. include:: ../README.rst
 

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,29 @@
 Release Notes
 =============
 
+
+0.10.3 | 2020-07-15
+^^^^^^^^^^^^^^^^^^^
+
+* Integrate arboreto multiprocessing script into pySCENIC CLI
+* Skip modules with zero db overlap in cisTarget step
+* Additional error message if regulons file is empty
+* Additional error if there is a mismatch between the genes present in the GRN and the expression matrix
+* Fixed bug in motif url construction when running without pruning
+
+
+0.10.2 | 2020-06-05
+^^^^^^^^^^^^^^^^^^^
+
+* Bugfix for CLI grn step
+
+
+0.10.1 | 2020-05-17
+^^^^^^^^^^^^^^^^^^^
+
+* CLI: file compression (optionally) enabled for intermediate files for the major steps: grn (adjacencies matrix), ctx (regulons), and aucell (auc matrix). Compression is used when the file name argument has a .gz ending.
+
+
 0.10.3 | 2020-07-15
 ^^^^^^^^^^^^^^^^^^^
 
@@ -9,6 +32,7 @@ Release Notes
 * Additional error message if regulons file is empty
 * Additional error if there is a mismatch between the genes present in the GRN and the expression matrix
 * Fixed bug in motif url construciton when running without pruning
+
 
 0.10.2 | 2020-06-05
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,0 +1,25 @@
+Release Notes
+=============
+
+0.10.2 | 2020-06-05
+^^^^^^^^^^^^^^^^^^^
+
+* Bugfix for CLI grn step
+
+
+0.10.1 | 2020-05-17
+^^^^^^^^^^^^^^^^^^^
+
+* CLI: file compression (optionally) enabled for intermediate files for the major steps: grn (adjacencies matrix), ctx (regulons), and aucell (auc matrix). Compression is used when the file name argument has a .gz ending.
+
+
+0.10.0 | 2020-02-27
+^^^^^^^^^^^^^^^^^^^
+
+* Added a helper script `arboreto_with_multiprocessing.py <https://github.com/aertslab/pySCENIC/blob/master/scripts/arboreto_with_multiprocessing.py>`_ that runs the Arboreto GRN algorithms (GRNBoost2, GENIE3) without Dask for compatibility.
+
+* Ability to set a fixed seed in both the AUCell step and in the calculation of regulon thresholds (CLI parameter :code:`--seed`; aucell function parameter :code:`seed`).
+
+* (since 0.9.18) In the modules_from_adjacencies function, the default value of :code:`rho_mask_dropouts` is changed to False. This now matches the behavior of the R version of SCENIC. The cli version has an additional option to turn dropout masking back on (:code:`--mask_dropouts`).
+
+

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+0.10.3 | 2020-07-15
+^^^^^^^^^^^^^^^^^^^
+
+* Integrate arboreto multiprocessing script into pySCENIC CLI
+* Skip modules with zero db overlap in cisTarget step
+* Additional error message if regulons file is empty
+* Additional error if there is a mismatch between the genes present in the GRN and the expression matrix
+* Fixed bug in motif url construciton when running without pruning
+
 0.10.2 | 2020-06-05
 ^^^^^^^^^^^^^^^^^^^
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/cflerin/arboreto.git@dev#egg=arboreto-post1
 cytoolz
 multiprocessing_on_dill
 llvmlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/cflerin/arboreto.git@dev#egg=arboreto-post1
+arboreto @ git+https://github.com/cflerin/arboreto@dev#egg=arboreto
 cytoolz
 multiprocessing_on_dill
 llvmlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ frozendict
 numpy
 pandas>=0.20.1
 cloudpickle
-dask==1.0.0
-distributed>=1.21.6,<2.0.0
+dask
+distributed
 pyarrow>=0.11.1,<0.17.0
 arboreto
 boltons

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numba
 attrs
 frozendict
 numpy
-pandas>=0.20.1,<1.0.0
+pandas>=0.20.1
 cloudpickle
 dask==1.0.0
 distributed>=1.21.6,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cytoolz
 multiprocessing_on_dill
 llvmlite
-numba
+numba>=0.51.2
 attrs
 frozendict
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ umap-learn
 loompy
 networkx
 scipy
+fsspec
+requests
+aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cloudpickle
 dask
 distributed
 pyarrow>=0.11.1,<0.17.0
-arboreto
+arboreto>=0.1.6
 boltons
 setuptools
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-arboreto @ git+https://github.com/cflerin/arboreto@dev#egg=arboreto
 cytoolz
 multiprocessing_on_dill
 llvmlite

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -2,8 +2,7 @@ adjustText==0.7.3
 anndata==0.6.22.post1
 annoy==1.15.2
 ansiwrap==0.8.4
-#arboreto==0.1.5
--e git+https://github.com/cflerin/arboreto.git@dev#egg=arboreto-post1
+arboreto @ git+https://github.com/cflerin/arboreto@dev#egg=arboreto
 attrs==19.3.0
 backcall==0.1.0
 bbknn==1.3.6

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -2,7 +2,8 @@ adjustText==0.7.3
 anndata==0.6.22.post1
 annoy==1.15.2
 ansiwrap==0.8.4
-arboreto==0.1.5
+#arboreto==0.1.5
+-e git+https://github.com/cflerin/arboreto.git@dev#egg=arboreto-post1
 attrs==19.3.0
 backcall==0.1.0
 bbknn==1.3.6

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -60,7 +60,7 @@ networkx==2.3
 numba==0.46.0
 numexpr==2.7.0
 numpy==1.17.2
-pandas==0.25.3
+pandas==1.0.3
 pandocfilters==1.4.2
 papermill==1.2.0
 parso==0.5.1

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -2,7 +2,7 @@ adjustText==0.7.3
 anndata==0.6.22.post1
 annoy==1.15.2
 ansiwrap==0.8.4
-arboreto @ git+https://github.com/cflerin/arboreto@dev#egg=arboreto
+arboreto==0.1.5
 attrs==19.3.0
 backcall==0.1.0
 bbknn==1.3.6

--- a/src/pyscenic/cli/db2feather.py
+++ b/src/pyscenic/cli/db2feather.py
@@ -2,7 +2,7 @@
 
 import os
 import argparse
-from pyscenic.rnkdb import convert2feather
+from pyscenic.rnkdb import convert_sqlitedb_to_featherdb
 
 
 def derive_db_name(fname:str) -> str:
@@ -25,7 +25,7 @@ def create_argument_parser():
 def convert(out_folder, in_fnames):
     for fname in in_fnames:
         print("Converting {}".format(fname.name))
-        convert2feather(fname.name, out_folder, derive_db_name(fname.name))
+        convert_sqlitedb_to_featherdb(fname.name, out_folder, derive_db_name(fname.name))
 
 
 def main():

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -238,7 +238,7 @@ def aucell_command(args):
         except OSError as e:
             LOGGER.error("Expression matrix should be provided in the loom file format.")
             sys.exit(1)
-    if '.h5ad' in extension:
+    elif '.h5ad' in extension:
         from pyscenic.export import add_scenic_metadata
         from anndata import read_h5ad
         # check input file is also h5ad:

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -206,7 +206,7 @@ def aucell_command(args):
     if '.loom' in extension:
         try:
             copyfile(args.expression_mtx_fname.name, args.output.name)
-            append_auc_mtx(args.output.name, auc_mtx, signatures, args.seed, args.num_workers)
+            append_auc_mtx(args.output.name, ex_mtx, auc_mtx, signatures, args.seed, args.num_workers)
         except OSError as e:
             LOGGER.error("Expression matrix should be provided in the loom file format.")
             sys.exit(1)

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -71,7 +71,10 @@ def find_adjacencies_command(args):
     client, shutdown_callback = _prepare_client(args.client_or_address, num_workers=args.num_workers)
     method = grnboost2 if args.method == 'grnboost2' else genie3
     try:
-        network = method(expression_data=ex_mtx, tf_names=tf_names, verbose=True, client_or_address=client, seed=args.seed)
+        if args.sparse:
+            network = method(expression_data=ex_mtx[0], gene_names=ex_mtx[1], tf_names=tf_names, verbose=True, client_or_address=client, seed=args.seed)
+        else:
+            network = method(expression_data=ex_mtx, tf_names=tf_names, verbose=True, client_or_address=client, seed=args.seed)
     finally:
         shutdown_callback(False)
 

--- a/src/pyscenic/cli/pyscenic.py
+++ b/src/pyscenic/cli/pyscenic.py
@@ -78,7 +78,7 @@ def find_adjacencies_command(args):
     LOGGER.info("Writing results to file.")
 
     extension = PurePath(args.output.name).suffixes
-    network.to_csv(args.output, index=False, sep=suffixes_to_separator(extension))
+    network.to_csv(args.output.name, index=False, sep=suffixes_to_separator(extension))
 
 
 def adjacencies2modules(args):

--- a/src/pyscenic/cli/utils.py
+++ b/src/pyscenic/cli/utils.py
@@ -260,7 +260,7 @@ def compress_meta(meta):
     return base64.b64encode(zlib.compress(json.dumps(meta).encode('ascii'))).decode('ascii')
 
 
-def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[GeneSignature]], seed=None, num_workers=1) -> None:
+def append_auc_mtx(fname: str, ex_mtx: pd.DataFrame, auc_mtx: pd.DataFrame, regulons: Sequence[Type[GeneSignature]], seed=None, num_workers=1) -> None:
     """
 
     Append AUC matrix to loom file.
@@ -289,7 +289,6 @@ def append_auc_mtx(fname: str, auc_mtx: pd.DataFrame, regulons: Sequence[Type[Ge
                            "motifData": name2logo.get(name, "")} for name, threshold in auc_thresholds.iteritems()]
 
     # Calculate the number of genes per cell.
-    ex_mtx = load_exp_matrix(fname)
     binary_mtx = ex_mtx.copy()
     binary_mtx[binary_mtx != 0] = 1.0
     ngenes = binary_mtx.sum(axis=1).astype(int)

--- a/src/pyscenic/cli/utils.py
+++ b/src/pyscenic/cli/utils.py
@@ -243,10 +243,7 @@ def load_modules(fname: str) -> Sequence[Type[GeneSignature]]:
         with openfile(fname, 'rb') as f:
             return pickle.load(f)
     elif '.gmt' in extension:
-        sep = guess_separator(fname)
-        return GeneSignature.from_gmt(fname,
-                                      field_separator=sep,
-                                      gene_separator=sep)
+        return GeneSignature.from_gmt(fname)
     else:
         raise ValueError("Unknown file format for \"{}\".".format(fname))
 

--- a/src/pyscenic/cli/utils.py
+++ b/src/pyscenic/cli/utils.py
@@ -189,7 +189,7 @@ def load_signatures(fname: str) -> Sequence[Type[GeneSignature]]:
         return GeneSignature.from_gmt(fname,
                                   field_separator=sep,
                                   gene_separator=sep)
-    elif extension == '.dat':
+    elif '.dat' in extension:
         with openfile(fname, 'rb') as f:
             return pickle.load(f)
     else:

--- a/src/pyscenic/genesig.py
+++ b/src/pyscenic/genesig.py
@@ -61,7 +61,7 @@ class GeneSignature(yaml.YAMLObject):
                              gene2weight=zip(data['genes'], data['weights']))
 
     @classmethod
-    def from_gmt(cls, fname: str, field_separator: str = ',', gene_separator: str = ',') -> List['GeneSignature']:
+    def from_gmt(cls, fname: str, field_separator: str = '\t', gene_separator: str = '\t') -> List['GeneSignature']:
         """
         Load gene signatures from a GMT file.
 
@@ -81,13 +81,13 @@ class GeneSignature(yaml.YAMLObject):
                     if line.startswith("#") or not line.strip():
                         continue
                     columns = re.split(field_separator, line.rstrip())
-                    genes = columns[2:] if field_separator == gene_separator else columns[2].split(gene_separator)
+                    genes = columns[2:]
                     yield GeneSignature(name=columns[0], gene2weight=genes)
         return list(signatures())
 
 
     @classmethod
-    def to_gmt(cls, fname: str, signatures: List[Type['GeneSignature']], field_separator: str = ',', gene_separator: str = ',') -> None:
+    def to_gmt(cls, fname: str, signatures: List[Type['GeneSignature']], field_separator: str = '\t', gene_separator: str = '\t') -> None:
         """
         Save list of signatures as GMT file.
 
@@ -101,7 +101,7 @@ class GeneSignature(yaml.YAMLObject):
             for signature in signatures:
                 genes = gene_separator.join(signature.genes)
                 file.write("{}{}{}{}{}\n".format(signature.name, field_separator,
-                                                 signature.metadata(gene_separator), field_separator,
+                                                 signature.metadata(','), field_separator,
                                                  genes))
 
 

--- a/src/pyscenic/math.py
+++ b/src/pyscenic/math.py
@@ -2,7 +2,7 @@
 
 
 import numpy as np
-from numba import njit, float64, int64
+from numba import njit, float64, int64, prange
 
 
 @njit(float64(float64[:], float64[:], float64))

--- a/src/pyscenic/math.py
+++ b/src/pyscenic/math.py
@@ -5,7 +5,7 @@ import numpy as np
 from numba import njit, float64, int64
 
 
-@njit(signature=float64(float64[:], float64[:], float64))
+@njit(float64(float64[:], float64[:], float64))
 def masked_rho(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> float:
     """
     Calculates the masked correlation coefficient of two vectors.
@@ -30,7 +30,7 @@ def masked_rho(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> float:
     return cov_xy / (std_x * std_y)
 
 
-@njit(signature=float64[:, :](float64[:, :], float64[:, :], float64), parallel=True)
+@njit(float64[:, :](float64[:, :], float64[:, :], float64), parallel=True)
 def masked_rho_2d(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> np.ndarray:
     """
     Calculates the masked correlation coefficients of two arrays.
@@ -50,7 +50,7 @@ def masked_rho_2d(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> np.ndarray
     return rhos
 
 
-@njit(signature=float64[:](float64[:, :], int64[:, :], float64), parallel=True)
+@njit(float64[:](float64[:, :], int64[:, :], float64), parallel=True)
 def masked_rho4pairs(mtx: np.ndarray, col_idx_pairs: np.ndarray, mask: float = 0.0) -> np.ndarray:
     """
     Calculates the masked correlation of columns pairs in a matrix.

--- a/src/pyscenic/math.py
+++ b/src/pyscenic/math.py
@@ -2,10 +2,10 @@
 
 
 import numpy as np
-from numba import *
+from numba import njit, float64, int64
 
 
-@njit(signature_or_function=float64(float64[:], float64[:], float64))
+@njit(signature=float64(float64[:], float64[:], float64))
 def masked_rho(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> float:
     """
     Calculates the masked correlation coefficient of two vectors.
@@ -30,7 +30,7 @@ def masked_rho(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> float:
     return cov_xy / (std_x * std_y)
 
 
-@njit(signature_or_function=float64[:, :](float64[:, :], float64[:, :], float64), parallel=True)
+@njit(signature=float64[:, :](float64[:, :], float64[:, :], float64), parallel=True)
 def masked_rho_2d(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> np.ndarray:
     """
     Calculates the masked correlation coefficients of two arrays.
@@ -50,7 +50,7 @@ def masked_rho_2d(x: np.ndarray, y: np.ndarray, mask: float = 0.0) -> np.ndarray
     return rhos
 
 
-@njit(signature_or_function=float64[:](float64[:, :], int64[:, :], float64), parallel=True)
+@njit(signature=float64[:](float64[:, :], int64[:, :], float64), parallel=True)
 def masked_rho4pairs(mtx: np.ndarray, col_idx_pairs: np.ndarray, mask: float = 0.0) -> np.ndarray:
     """
     Calculates the masked correlation of columns pairs in a matrix.
@@ -67,3 +67,4 @@ def masked_rho4pairs(mtx: np.ndarray, col_idx_pairs: np.ndarray, mask: float = 0
         y = mtx[:, col_idx_pairs[n_idx, 1]]
         rhos[n_idx] = masked_rho(x, y, mask)
     return rhos
+

--- a/src/pyscenic/recovery.py
+++ b/src/pyscenic/recovery.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 from itertools import repeat
 from typing import Type, Optional, List, Tuple
-from numba import *
+from numba import jit
 import logging
 
 from .rnkdb import RankingDatabase

--- a/src/pyscenic/rnkdb.py
+++ b/src/pyscenic/rnkdb.py
@@ -396,7 +396,7 @@ class InvertedRankingDatabase(RankingDatabase):
         self.idx2identifier = {idx: identifier for identifier, idx in self.identifier2idx.items()}
 
         # Load dataframe into memory in a format most suited for fast loading of gene signatures.
-        df = FeatherReader(fname).read().set_index(INDEX_NAME)
+        df = FeatherReader(fname).read_pandas().set_index(INDEX_NAME)
         self.max_rank = len(df.columns)
         self.features = [pd.Series(index=row.values, data=row.index, name=name) for name, row in df.iterrows()]
 

--- a/src/pyscenic/rnkdb.py
+++ b/src/pyscenic/rnkdb.py
@@ -548,14 +548,14 @@ class InvertedRankingDatabase(RankingDatabase):
                          axis=1).T.astype(INVERTED_DB_DTYPE).rename(columns=self.idx2identifier)
 
 
-def convert2feather(fname: str, out_folder: str, name: str, extension: str="feather") -> str:
+def convert_sqlitedb_to_featherdb(fname: str, out_folder: str, name: str, extension: str= "feather") -> str:
     """
-    Convert a whole genome rankings database to a feather format based database.
+    Convert a whole genome SQLite rankings database to a feather format based database.
 
     More information on this format can be found here:
     .. feather-format: https://blog.rstudio.com/2016/03/29/feather/
 
-    :param fname: The filename of the legacy
+    :param fname: The filename of the legacy SQLite rankings database.
     :param out_folder: The name of the folder to write the new database to.
     :param name: The name of the rankings database.
     :param extension: The extension of the new database file.
@@ -572,7 +572,8 @@ def convert2feather(fname: str, out_folder: str, name: str, extension: str="feat
     db = SQLiteRankingDatabase(fname=fname, name=name)
     df = db.load_full()
     df.index.name = INDEX_NAME
-    df.reset_index(inplace=True) # Index is not stored in feather format. https://github.com/wesm/feather/issues/200
+    # Index is not stored in feather format: https://github.com/wesm/feather/issues/200
+    df.reset_index(inplace=True)
     write_feather(df, feather_fname)
     return feather_fname
 

--- a/src/pyscenic/rnkdb.py
+++ b/src/pyscenic/rnkdb.py
@@ -305,9 +305,11 @@ class FeatherRankingDatabase(RankingDatabase):
         return df
 
     def load(self, gs: Type[GeneSignature]) -> pd.DataFrame:
+        # For some genes in the signature there might not be a rank available in the database.
+        gene_set = self.geneset.intersection(set(gs.genes))
         # Read ranking columns for genes in order they appear in the Feather file.
         df = FeatherReader(self._fname).read_pandas(
-            columns=(INDEX_NAME,) + sorted(gs.genes, key=lambda gene: self.genes2idx[gene])
+            columns=(INDEX_NAME,) + tuple(sorted(gene_set, key=lambda gene: self.genes2idx[gene]))
         )
         # Avoid copying the whole dataframe by replacing the index in place.
         # This makes loading a database twice as fast in case the database file is already in the filesystem cache.
@@ -363,10 +365,12 @@ class ParquetRankingDatabase(RankingDatabase):
         return df
 
     def load(self, gs: Type[GeneSignature]) -> pd.DataFrame:
+        # For some genes in the signature there might not be a rank available in the database.
+        gene_set = self.geneset.intersection(set(gs.genes))
         # Read rankings columns for genes in order they appear in the Parquet file.
         df = pq.read_pandas(
             self._fname,
-            columns=(INDEX_NAME,) + sorted(gs.genes, key=lambda gene: self.genes2idx[gene])
+            columns=(INDEX_NAME,) + tuple(sorted(gene_set, key=lambda gene: self.genes2idx[gene]))
         ).to_pandas()
         # Avoid copying the whole dataframe by replacing the index in place.
         # This makes loading a database twice as fast in case the database file is already in the filesystem cache.

--- a/src/pyscenic/rnkdb.py
+++ b/src/pyscenic/rnkdb.py
@@ -277,6 +277,7 @@ class FeatherRankingDatabase(RankingDatabase):
     @property
     @memoize
     def total_genes(self) -> int:
+        # Do not count column 1 as it contains the index with the name of the features.
         return FeatherReader(self._fname).num_columns - 1
 
     @property
@@ -284,7 +285,11 @@ class FeatherRankingDatabase(RankingDatabase):
     def genes(self) -> Tuple[str]:
         # noinspection PyTypeChecker
         reader = FeatherReader(self._fname)
-        return tuple(reader.get_column_name(idx) for idx in range(self.total_genes) if reader.get_column_name(idx) != INDEX_NAME)
+        # Get all gene names (exclude "features" column).
+        return tuple(
+            reader.get_column_name(idx) for idx in range(reader.num_columns)
+            if reader.get_column_name(idx) != INDEX_NAME
+        )
 
     def load_full(self) -> pd.DataFrame:
         df = FeatherReader(self._fname).read_pandas()

--- a/src/pyscenic/transform.py
+++ b/src/pyscenic/transform.py
@@ -224,7 +224,10 @@ def module2df(db: Type[RankingDatabase], module: Regulon, motif_annotations: pd.
     del df['Ranking']
     if not return_recovery_curves:
         del df['Recovery']
-    return df
+        assert all([ col in df.columns for col in DF_META_DATA ]), f"Column comparison to expected metadata failed! Found:\n{df.columns}"
+        return df[DF_META_DATA.columns]
+    else:
+        return df
 
 
 def modules2df(db: Type[RankingDatabase], modules: Sequence[Regulon], motif_annotations: pd.DataFrame,

--- a/src/pyscenic/transform.py
+++ b/src/pyscenic/transform.py
@@ -300,6 +300,7 @@ def df2regulons(df, save_columns=[]) -> Sequence[Regulon]:
     :return: A sequence of regulons.
     """
     
+    assert not df.empty, 'Signatures dataframe is empty!'
     print("Create regulons from a dataframe of enriched features.")
     print("Additional columns saved: {}".format(save_columns))
 

--- a/src/pyscenic/transform.py
+++ b/src/pyscenic/transform.py
@@ -124,6 +124,11 @@ def module2features_auc1st_impl(db: Type[RankingDatabase], module: Regulon, moti
     features, genes, rankings = df.index.values, df.columns.values, df.values
     weights = np.asarray([module[gene] for gene in genes]) if weighted_recovery else np.ones(len(genes))
 
+    # include check for modules with no genes that could be mapped to the db. This can happen when including non protein-coding genes in the expression matrix.
+    if(df.empty):
+        LOGGER.warning("No genes in module {} could be mapped to {}. Skipping this module.".format(module.name, db.name))
+        return pd.DataFrame(), None, None, genes, None
+
     # Calculate recovery curves, AUC and NES values.
     # For fast unweighted implementation so weights to None.
     aucs = calc_aucs(df, db.total_genes, weights, auc_threshold)

--- a/src/pyscenic/utils.py
+++ b/src/pyscenic/utils.py
@@ -263,6 +263,9 @@ def modules_from_adjacencies(adjacencies: pd.DataFrame,
 
         # Add correlation column and create two disjoint set of adjacencies.
         LOGGER.info("Calculating Pearson correlations.")
+        # test for genes present in the adjacencies but not present in the expression matrix:
+        unique_adj_genes = set(adjacencies[COLUMN_NAME_TF]).union(set(adjacencies[COLUMN_NAME_TARGET])) - set(ex_mtx.columns)
+        assert len(unique_adj_genes)==0, f"Found {len(unique_adj_genes)} genes present in the network (adjacencies) output, but missing from the expression matrix. Is this a different gene expression matrix?"
         LOGGER.warn(f"Note on correlation calculation: the default behaviour for calculating the correlations has changed after pySCENIC verion 0.9.16. Previously, the default was to calculate the correlation between a TF and target gene using only cells with non-zero expression values (mask_dropouts=True). The current default is now to use all cells to match the behavior of the R verision of SCENIC. The original settings can be retained by setting 'rho_mask_dropouts=True' in the modules_from_adjacencies function, or '--mask_dropouts' from the CLI.\n\tDropout masking is currently set to [{rho_mask_dropouts}].")
         adjacencies = add_correlation(adjacencies, ex_mtx,
                                   rho_threshold=rho_threshold, mask_dropouts=rho_mask_dropouts)

--- a/src/pyscenic/utils.py
+++ b/src/pyscenic/utils.py
@@ -319,7 +319,7 @@ def add_motif_url(df: pd.DataFrame, base_url: str):
     :param base_url:
     :return:
     """
-    df[("Enrichment", COLUMN_NAME_MOTIF_URL)] = list(map(partial(urljoin, base=base_url), df.index.get_level_values(COLUMN_NAME_MOTIF_ID)))
+    df[("Enrichment", COLUMN_NAME_MOTIF_URL)] = list(map(partial(urljoin, base_url), df.index.get_level_values(COLUMN_NAME_MOTIF_ID)))
     return df
 
 

--- a/tests/test_aucell.py
+++ b/tests/test_aucell.py
@@ -8,8 +8,6 @@ from pyscenic.genesig import GeneSignature
 from pyscenic.aucell import derive_auc_threshold, aucell, create_rankings
 from pkg_resources import resource_filename
 
-
-
 NOMENCLATURE = "HGNC"
 TEST_EXPRESSION_MTX_FNAME = resource_filename('resources.tests', "GSE103322.em.hgnc.sample.cxg.csv")
 TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols.gmt")
@@ -22,15 +20,14 @@ def exp_matrix():
 
 @pytest.fixture
 def gs():
-    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME,
-                                  gene_separator="\t", field_separator="\t", )
+    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME, gene_separator="\t", field_separator="\t", )
 
 
 def test_create_rankings(exp_matrix):
     df_rnk = create_rankings(exp_matrix)
     n_genes = exp_matrix.shape[1]
     assert len(df_rnk.sum(axis=1).unique()) == 1
-    assert (df_rnk + 1).sum(axis=1).unique()[0] == (n_genes * (n_genes+1))/2.0
+    assert (df_rnk + 1).sum(axis=1).unique()[0] == (n_genes * (n_genes + 1)) / 2.0
 
 
 def test_aucell_w1(exp_matrix, gs):
@@ -48,6 +45,3 @@ def test_aucell_mismatch(exp_matrix, gs):
     gss = [GeneSignature(name="test", gene2weight=list(map("FAKE{}".format, range(100))))] + gs
     aucs_mtx = aucell(exp_matrix, gss, auc_threshold=percentiles[0.01], num_workers=1)
     print(aucs_mtx.head())
-
-
-

--- a/tests/test_featherdb.py
+++ b/tests/test_featherdb.py
@@ -18,13 +18,16 @@ def db():
 @pytest.fixture
 def gs():
     return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME,
-                                    gene_separator="\t", field_separator="\t", )[0]
+                                  gene_separator="\t", field_separator="\t", )[0]
 
 def test_init(db):
     assert db.name == TEST_DATABASE_NAME
 
 def test_total_genes(db):
     assert db.total_genes == 22284
+
+def test_genes(db):
+    assert len(db.genes) == 22284
 
 def test_load_full(db):
     rankings = db.load_full()

--- a/tests/test_featherdb.py
+++ b/tests/test_featherdb.py
@@ -1,38 +1,43 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from pyscenic.rnkdb import FeatherRankingDatabase as RankingDatabase
-from pyscenic.genesig import GeneSignature
 from pkg_resources import resource_filename
 
+from pyscenic.genesig import GeneSignature
+from pyscenic.rnkdb import FeatherRankingDatabase as RankingDatabase
 
 TEST_DATABASE_FNAME = resource_filename('resources.tests', "hg19-tss-centered-10kb-10species.mc9nr.feather")
 TEST_DATABASE_NAME = "hg19-tss-centered-10kb-10species.mc9nr"
-TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "/c6.all.v6.1.symbols.gmt")
+TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols.gmt")
 
 
 @pytest.fixture
 def db():
     return RankingDatabase(TEST_DATABASE_FNAME, TEST_DATABASE_NAME)
 
+
 @pytest.fixture
 def gs():
-    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME,
-                                  gene_separator="\t", field_separator="\t", )[0]
+    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME, gene_separator="\t", field_separator="\t", )[0]
+
 
 def test_init(db):
     assert db.name == TEST_DATABASE_NAME
 
+
 def test_total_genes(db):
     assert db.total_genes == 22284
 
+
 def test_genes(db):
     assert len(db.genes) == 22284
+
 
 def test_load_full(db):
     rankings = db.load_full()
     assert len(rankings.index) == 5
     assert len(rankings.columns) == 22284
+
 
 def test_load(db, gs):
     rankings = db.load(gs)

--- a/tests/test_featureseq.py
+++ b/tests/test_featureseq.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 
-from pyscenic.featureseq import Feature, FeatureSeq
+from pyscenic.featureseq import Feature
 
 
 def test_feature_overlap():
@@ -33,5 +33,3 @@ def test_feature_bp_overlap():
     assert f2.get_overlap_in_bp_with(f3) == 0
     assert f3.get_overlap_in_bp_with(f4) == 0
     assert f3.get_overlap_in_bp_with(f3) == len(f3)
-
-

--- a/tests/test_genesig.py
+++ b/tests/test_genesig.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from pyscenic.genesig import GeneSignature, Regulon
-from configparser import ConfigParser
-import os
-import pytest
 import attr
+import pytest
 from pkg_resources import resource_filename
 
+from pyscenic.genesig import GeneSignature, Regulon
 
 TEST_SIGNATURE = "msigdb_cancer_c6"
 TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols.gmt")
@@ -40,7 +38,7 @@ def test_init3():
     assert len(gs1) == 2
     assert gs1.gene2weight['TP53'] == 0.5
     assert gs1.gene2weight['SOX4'] == 0.75
-    
+
 
 def test_immut():
     gs1 = GeneSignature(name="test1", gene2weight={'TP53': 0.5, 'SOX4': 0.75})
@@ -80,6 +78,7 @@ def test_union1():
     assert 'SOX4' in gsu
     assert 'SOX2' in gsu
     assert len(gsu) == 3
+
 
 def test_union3():
     gs1 = GeneSignature(name="test1", gene2weight={'TP53': 0.8, 'SOX4': 0.75})
@@ -134,8 +133,7 @@ def test_regulon():
 
 
 def test_load_gmt():
-    gss = GeneSignature.from_gmt(field_separator='\t', gene_separator='\t',
-                                 fname=TEST_SIGNATURE_FNAME)
+    gss = GeneSignature.from_gmt(field_separator='\t', gene_separator='\t', fname=TEST_SIGNATURE_FNAME)
     # http://software.broadinstitute.org/gsea/msigdb/collections.jsp#C6
     assert len(gss) == 189
     assert gss[0].name == "GLI1_UP.V1_DN"
@@ -144,8 +142,7 @@ def test_load_gmt():
 
 
 def test_add():
-    gss = GeneSignature.from_gmt(field_separator='\t', gene_separator='\t',
-                                 fname=TEST_SIGNATURE_FNAME)
+    gss = GeneSignature.from_gmt(field_separator='\t', gene_separator='\t', fname=TEST_SIGNATURE_FNAME)
     res = gss[0].add("MEF2")
     assert "MEF2" in res
 
@@ -162,6 +159,7 @@ def test_noweights():
     assert reg2['TP53'] == 1.0
     assert isinstance(reg2, Regulon)
 
+
 def test_head():
     gs1 = GeneSignature(name="test1", gene2weight={'TP53': 0.8, 'SOX4': 0.75})
     gs2 = gs1.head(1)
@@ -171,4 +169,3 @@ def test_head():
     assert gs2['TP53'] == 0.8
     assert gs2['SOX4'] == 0.75
     assert len(gs2) == 2
-

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -7,7 +7,7 @@ from pyscenic.math import masked_rho
 
 
 def test_masked_rho():
-    x = np.array([1, 2, -1, 0.0, 4], dtype=np.float)
-    y = np.array([1, 2, 0.0, -8, 4], dtype=np.float)
+    x = np.array([1, 2, -1, 0.0, 4], dtype=float)
+    y = np.array([1, 2, 0.0, -8, 4], dtype=float)
     assert pytest.approx(masked_rho(x, y, 0.0), 0.00001) == \
            np.corrcoef(np.array([1.0, 2.0, 4.0]), np.array([1.0, 2.0, 4.0]))[0, 1]

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,12 +1,13 @@
 # coding=utf-8
 
-import pytest
 import numpy as np
-from pyscenic.math import masked_rho, masked_rho_2d
+import pytest
+
+from pyscenic.math import masked_rho
 
 
 def test_masked_rho():
     x = np.array([1, 2, -1, 0.0, 4], dtype=np.float)
-    y = np.array([1, 2, 0.0, -8, 4],  dtype=np.float)
-    assert pytest.approx(masked_rho(x, y, 0.0), 0.00001) == np.corrcoef(np.array([1.0, 2.0, 4.0]), np.array([1.0, 2.0, 4.0]))[0, 1]
-
+    y = np.array([1, 2, 0.0, -8, 4], dtype=np.float)
+    assert pytest.approx(masked_rho(x, y, 0.0), 0.00001) == \
+           np.corrcoef(np.array([1.0, 2.0, 4.0]), np.array([1.0, 2.0, 4.0]))[0, 1]

--- a/tests/test_parquetdb.py
+++ b/tests/test_parquetdb.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from pkg_resources import resource_filename
+
+from pyscenic.genesig import GeneSignature
+from pyscenic.rnkdb import ParquetRankingDatabase as RankingDatabase
+
+TEST_DATABASE_FNAME = resource_filename('resources.tests', "hg19-tss-centered-10kb-10species.mc9nr.parquet")
+TEST_DATABASE_NAME = "hg19-tss-centered-10kb-10species.mc9nr"
+TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols.gmt")
+
+
+@pytest.fixture
+def db():
+    return RankingDatabase(TEST_DATABASE_FNAME, TEST_DATABASE_NAME)
+
+
+@pytest.fixture
+def gs():
+    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME, gene_separator="\t", field_separator="\t", )[0]
+
+
+def test_init(db):
+    assert db.name == TEST_DATABASE_NAME
+
+
+def test_total_genes(db):
+    assert db.total_genes == 22284
+
+
+def test_genes(db):
+    assert len(db.genes) == 22284
+
+
+def test_load_full(db):
+    rankings = db.load_full()
+    assert len(rankings.index) == 5
+    assert len(rankings.columns) == 22284
+
+
+def test_load(db, gs):
+    rankings = db.load(gs)
+    assert len(rankings.index) == 5
+    assert len(rankings.columns) == 29

--- a/tests/test_parquetdb.py
+++ b/tests/test_parquetdb.py
@@ -10,6 +10,11 @@ TEST_DATABASE_FNAME = resource_filename('resources.tests', "hg19-tss-centered-10
 TEST_DATABASE_NAME = "hg19-tss-centered-10kb-10species.mc9nr"
 TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols.gmt")
 
+##################################################
+# temporarily disable testing of the parqet databases until we have a working test database
+from os import path
+pytestmark = pytest.mark.skipif(not path.exists(TEST_DATABASE_FNAME), reason="Parquet testing is temporarily disabled.")
+##################################################
 
 @pytest.fixture
 def db():

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from pyscenic.recovery import enrichment4features as enrichment, auc1d, weighted_auc1d, rcc2d
-
-import pytest
 import numpy as np
-from pyscenic.rnkdb import FeatherRankingDatabase as RankingDatabase
-from pyscenic.genesig import GeneSignature
+import pytest
 from pkg_resources import resource_filename
 
+from pyscenic.genesig import GeneSignature
+from pyscenic.recovery import enrichment4features as enrichment, auc1d, weighted_auc1d, rcc2d
+from pyscenic.rnkdb import FeatherRankingDatabase as RankingDatabase
 
 TEST_DATABASE_FNAME = resource_filename('resources.tests', "hg19-tss-centered-10kb-10species.mc9nr.feather")
 TEST_DATABASE_NAME = "hg19-tss-centered-10kb-10species.mc9nr"
@@ -16,13 +15,12 @@ TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols
 
 @pytest.fixture
 def db():
-    return RankingDatabase(TEST_DATABASE_FNAME, TEST_DATABASE_NAME,)
+    return RankingDatabase(TEST_DATABASE_FNAME, TEST_DATABASE_NAME, )
 
 
 @pytest.fixture
 def gs():
-    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME,
-                                  gene_separator="\t", field_separator="\t", )[0]
+    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME, gene_separator="\t", field_separator="\t", )[0]
 
 
 def test_enrichment(db, gs):
@@ -32,38 +30,48 @@ def test_enrichment(db, gs):
 def test_auc1d_1():
     # Check if AUC is calculated correctly when a gene is recovered at the rank threshold.
     # In the python implementation it should be included in the AUC calculation.
-    # For the current gene list the non-normalized AUC should be (2*1)+(2*2)+(2*3)+(1*4) = 16.
+    # For the current gene list the non-normalized AUC should be: (2*1) + (2*2) + (2*3) + (1*4) = 16.
+
     total_genes = 100
-    auc_rank_threshold = 8 # This rank threshold is inclusive.
-    ranking = np.asarray([2, 4, 6, 8]) - 1 # The databases have a zero-based ranking system
+    # This rank threshold is inclusive.
+    auc_rank_threshold = 8
+    # The databases have a zero-based ranking system.
+    ranking = np.asarray([2, 4, 6, 8]) - 1
     auc_max = auc_rank_threshold * total_genes
-    assert 16.0/800 == auc1d(ranking, auc_rank_threshold, auc_max)
+    assert 16.0 / 800 == auc1d(ranking, auc_rank_threshold, auc_max)
 
 
 def test_auc1d_2():
-    # For the current gene list the non-normalized AUC should be (2*1)+(2*2)+(3*3) = 15.
+    # For the current gene list the non-normalized AUC should be: (2*1) + (2*2) + (3*3) = 15.
+
     total_genes = 100
-    auc_rank_threshold = 8 # This rank threshold is inclusive.
-    ranking = np.asarray([2, 4, 6]) - 1 # The databases have a zero-based ranking system
+    # This rank threshold is inclusive.
+    auc_rank_threshold = 8
+    # The databases have a zero-based ranking system.
+    ranking = np.asarray([2, 4, 6]) - 1
     auc_max = auc_rank_threshold * total_genes
-    assert 15.0/800 == auc1d(ranking, auc_rank_threshold, auc_max)
+    assert 15.0 / 800 == auc1d(ranking, auc_rank_threshold, auc_max)
 
 
 def test_weighted_auc1d():
     # CAVE: In python the ranking databases are 0-based. The only difference a 1-based system has on the calc
-    # of the AUC is that in the latter the rank threshold would not be included. This has an infuence on the
+    # of the AUC is that in the latter the rank threshold would not be included. This has an influence on the
     # normalization factor max AUC but nothing else.
+
     total_genes = 100
     auc_rank_threshold = 8
-    ranking = np.asarray([2, 4, 6]) - 1 # The databases have a zero-based ranking system
+    # The databases have a zero-based ranking system.
+    ranking = np.asarray([2, 4, 6]) - 1
     weights = np.ones(len(ranking))
-    auc_max = 1.0 # Disable normalization.
+    # Disable normalization.
+    auc_max = 1.0
     assert 15.0 == weighted_auc1d(ranking, weights, auc_rank_threshold, auc_max)
 
 
 def test_weighted_auc1d_batch():
-    # The assumption taken here is that for weights uniformely being set to 1.0, auc1d and
-    # weighted_auc1d should always have the same output.
+    # The assumption taken here is that for weights uniformly being set to 1.0,
+    # auc1d and weighted_auc1d should always have the same output.
+
     N = 100000
     total_genes = 100
     for _ in range(N):
@@ -71,23 +79,28 @@ def test_weighted_auc1d_batch():
         n_genes = np.random.randint(20, high=total_genes)
         ranking = np.random.randint(low=0, high=total_genes, size=n_genes)
         weights = np.ones(n_genes)
-        auc_max = 1.0 # Disable normalization.
-        assert auc1d(ranking, auc_rank_threshold, auc_max) == weighted_auc1d(ranking, weights, auc_rank_threshold, auc_max)
+        # Disable normalization.
+        auc_max = 1.0
+        assert auc1d(ranking, auc_rank_threshold, auc_max) \
+               == weighted_auc1d(ranking, weights, auc_rank_threshold, auc_max)
 
 
 def test_weighted_rcc2d_batch():
-    # The assumption taken here is that for weights uniformely being set to 1.0, auc1d and
-    # weighted_auc1d should always have the same output.
+    # The assumption taken here is that for weights uniformly being set to 1.0,
+    # auc1d and weighted_auc1d should always have the same output.
+
     N = 100000
     total_genes = 100
     for _ in range(N):
-        #rccs[row_idx, :] = np.cumsum(np.bincount(curranking, weights=weights)[:rank_threshold])
-        #ValueError: could not broadcast input array from shape (89) into shape (97)
+        # rccs[row_idx, :] = np.cumsum(np.bincount(curranking, weights=weights)[:rank_threshold])
+        # ValueError: could not broadcast input array from shape (89) into shape (97)
         auc_rank_threshold = np.random.randint(2, high=total_genes)
         n_genes = np.random.randint(20, high=total_genes)
         ranking = np.random.randint(low=0, high=total_genes, size=n_genes)
         rankings = ranking.reshape((1, n_genes))
         rankings = np.append(rankings, np.full(shape=(1, 1), fill_value=total_genes), axis=1)
         weights = np.ones(n_genes)
-        auc_max = 1.0 # Disable normalization.
-        assert rcc2d(rankings, np.insert(weights, len(weights), 0.0), total_genes)[:, :auc_rank_threshold].sum(axis=1) == weighted_auc1d(ranking, weights, auc_rank_threshold, auc_max)
+        # Disable normalization.
+        auc_max = 1.0
+        assert rcc2d(rankings, np.insert(weights, len(weights), 0.0), total_genes)[:, :auc_rank_threshold].sum(axis=1) \
+               == weighted_auc1d(ranking, weights, auc_rank_threshold, auc_max)

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -28,6 +28,9 @@ def test_init(db):
 def test_total_genes(db):
     assert db.total_genes == 29
 
+def test_genes(db):
+    assert len(db.genes) == 29
+
 def test_load_full(db):
     rankings = db.load_full()
     assert len(rankings.index) == 24453

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from pyscenic.rnkdb import SQLiteRankingDatabase as RankingDatabase
-from pyscenic.genesig import GeneSignature
 from pkg_resources import resource_filename
 
-
+from pyscenic.genesig import GeneSignature
+from pyscenic.rnkdb import SQLiteRankingDatabase as RankingDatabase
 
 TEST_DATABASE_FNAME = resource_filename('resources.tests', "hg19-tss-centered-5kb-10species.mc9nr.db")
 TEST_DATABASE_NAME = "hg19-tss-centered-5kb-10species.mc9nr"
@@ -16,25 +15,29 @@ TEST_SIGNATURE_FNAME = resource_filename('resources.tests', "c6.all.v6.1.symbols
 def db():
     return RankingDatabase(TEST_DATABASE_FNAME, TEST_DATABASE_NAME)
 
+
 @pytest.fixture
 def gs():
-    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME,
-                                  gene_separator="\t", field_separator="\t", )[0]
+    return GeneSignature.from_gmt(TEST_SIGNATURE_FNAME, gene_separator="\t", field_separator="\t", )[0]
 
 
 def test_init(db):
     assert db.name == TEST_DATABASE_NAME
 
+
 def test_total_genes(db):
     assert db.total_genes == 29
 
+
 def test_genes(db):
     assert len(db.genes) == 29
+
 
 def test_load_full(db):
     rankings = db.load_full()
     assert len(rankings.index) == 24453
     assert len(rankings.columns) == 29
+
 
 def test_load(db, gs):
     rankings = db.load(gs)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py36,py37,py38
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
**Major features:**

* Updated [Arboreto](https://github.com/aertslab/arboreto) release (GRN inference step) includes:

  * Support for sparse matrices (using the `--sparse` flag in `pyscenic grn`, or passing a sparse matrix to `grnboost2`/`genie3`).
  * Fixes to avoid dask metadata mismatch error

* Updated cisTarget:

  * Fix for metadata mismatch in ctx prune2df step
  * Support for databases Apache Parquet format
  * Faster loading from feather databases
  * Bugfix: loading genes from a database (previously missing the last gene name in the database)

* Support for Anndata input and output

* Package updates:

  * Upgrade to newer pandas version
  * Upgrade to newer numba version
  * Upgrade to newer versions of dask, distributed

* Input checks and more descriptive error messages.

  * Check that regulons loaded are not empty.

* Bugfixes:

  * Motif url construction fixed when running ctx without pruning
  * Compression of intermediate files in the CLI steps
  * Handle loom files with non-standard gene/cell attribute names
  * Reformat the genesig gmt input/output
  * Fix AUCell output to loom with non-standard loom attributes