### PR TITLE
Fix motif annotation selection when using clustered motif dbs

### DIFF
--- a/src/pyscenic/transform.py
+++ b/src/pyscenic/transform.py
@@ -179,6 +179,9 @@ def module2features_auc1st_impl(
 
     # Find motif annotations for enriched features.
     annotated_features = pd.merge(enriched_features, motif_annotations, how="left", left_index=True, right_index=True)
+    # When using cluster db annotations, keep direct if available otherwise use other (extended)
+    annotated_features = annotated_features.sort_values(["MotifSimilarityQvalue", "OrthologousIdentity"], ascending = [False, True])
+    annotated_features = annotated_features[~annotated_features.index.duplicated(keep='last')]
     annotated_features_idx = (
         pd.notnull(annotated_features[COLUMN_NAME_ANNOTATION])
         if filter_for_annotation


### PR DESCRIPTION
When using the cluster database, it is possible to have a TF annotated to a cluster directly and indirectly (because we pull the annotations of all motifs in the cluster). This causes problems in the code when merging the annotation to the motif enrichment table in `module2features_auc1st_impl` as the same cluster can appear in more than a row in the annotation. This is a small fix in which we keep the direct annotation if available (so it will be part of direct regulons); if the cluster has only indirect annotations we take one (and will be part of extended regulons).