### PR TITLE
Pin numpy until np.object is not used anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ llvmlite
 numba>=0.51.2
 attrs
 frozendict
-numpy
+numpy<=1.23.5
 pandas>=1.3.5
 numexpr
 cloudpickle


### PR DESCRIPTION
This PR pins numpy to avoid issues on fresh installations as described in #477 .

If you had this already on some other branch waiting to be merged, feel free to disregard of course.